### PR TITLE
Numberparser isParseable

### DIFF
--- a/src/Utils/Parser/NumberParser.php
+++ b/src/Utils/Parser/NumberParser.php
@@ -74,4 +74,17 @@ final class NumberParser
     {
         return $this->parse($string);
     }
+
+    /**
+     * Gibt zurück, ob ein String in Zahlen geparsed werden kann
+     * Dies ist immer der Fall, wenn der String mind. eine Zahl enthält
+     *
+     * @param string $string
+     *
+     * @return bool
+     */
+    public function isParseable(string $string): bool
+    {
+        return preg_match('/\\d/', $string);
+    }
 }

--- a/tests/Utils/Parser/NumberParserTest.php
+++ b/tests/Utils/Parser/NumberParserTest.php
@@ -75,4 +75,30 @@ final class NumberParserTest extends TestCase
             $this->assertEquals(-1234.0, $this->parser->parseFloat('-12-34'));
         });
     }
+
+    public function testIsParseable()
+    {
+        $this->specify('Mit Zahlen', function () {
+            $this->assertTrue($this->parser->isParseable('10.000€'));
+        });
+
+        $this->specify('Mit Zahlen (sinnlos)', function () {
+            $this->assertTrue($this->parser->isParseable('1ab5hd5'));
+        });
+        $this->specify('Mit Zahlen (Trennzeichen)', function () {
+            $this->assertTrue($this->parser->isParseable('52.658,63€'));
+        });
+
+        $this->specify('Nur Zahlen', function () {
+            $this->assertTrue($this->parser->isParseable('10000'));
+        });
+
+        $this->specify('Ohne Zahlen', function () {
+            $this->assertFalse($this->parser->isParseable('tausend euro'));
+        });
+
+        $this->specify('leer', function () {
+            $this->assertFalse($this->parser->isParseable(''));
+        });
+    }
 }


### PR DESCRIPTION
@kevindemv Kannste dann entsprechend im Fragebogen nutzen.
Auf die Exception habe ich bewusst verzichtet, da sie in diesem Kontext wenig Sinn macht und die Nutzung nur komplizierter macht.