### PR TITLE
Update Bedarfsthemen for new Beratung

### DIFF
--- a/src/Werte/Bedarf/Thema/Themen/Firmenrechtsschutz.php
+++ b/src/Werte/Bedarf/Thema/Themen/Firmenrechtsschutz.php
@@ -3,7 +3,7 @@
 namespace Demv\Werte\Bedarf\Thema\Themen;
 
 use Demv\Werte\Bedarf\Thema\Bedarfsthema;
-use Demv\Werte\Sparte\Sparten\Gewerbe;
+use Demv\Werte\Sparte\Sparten\RechtsschutzGewerbe;
 
 /**
  * Class Firmenrechtsschutz
@@ -15,6 +15,13 @@ class Firmenrechtsschutz extends Bedarfsthema
 
     public function __construct()
     {
-        parent::__construct(self::ID, 'Firmenrechtsschutz', [Gewerbe::RECHTSSCHUTZ]);
+        parent::__construct(self::ID, 'Firmenrechtsschutz', [
+            RechtsschutzGewerbe::ID,
+            RechtsschutzGewerbe::BERUF,
+            RechtsschutzGewerbe::VERKEHR,
+            RechtsschutzGewerbe::MIETER_EIGENTUEMER,
+            RechtsschutzGewerbe::VERMIETER,
+            RechtsschutzGewerbe::FIRMEN,
+        ]);
     }
 }

--- a/src/Werte/Bedarf/Thema/Themen/Funktionsinvaliditaet.php
+++ b/src/Werte/Bedarf/Thema/Themen/Funktionsinvaliditaet.php
@@ -3,7 +3,9 @@
 namespace Demv\Werte\Bedarf\Thema\Themen;
 
 use Demv\Werte\Bedarf\Thema\Bedarfsthema;
+use Demv\Werte\Sparte\Sparten\PrivateSachversicherung;
 use Demv\Werte\Sparte\Sparten\Unfallversicherung;
+use Demv\Werte\Sparte\Sparten\Vorsorge;
 
 /**
  * Class Funktionsinvaliditaet
@@ -15,6 +17,10 @@ class Funktionsinvaliditaet extends Bedarfsthema
 
     public function __construct()
     {
-        parent::__construct(self::ID, 'Multi-Risk', [Unfallversicherung::FUNKTIONSINVALIDITAET]);
+        parent::__construct(self::ID, 'Multi-Risk', [
+            Unfallversicherung::FUNKTIONSINVALIDITAET,
+            PrivateSachversicherung::MULTIRISK_VERSICHERUNG,
+            Vorsorge::MULTIRISK_INVALIDITAET,
+        ]);
     }
 }

--- a/src/Werte/Bedarf/Thema/Themen/Photovoltaik.php
+++ b/src/Werte/Bedarf/Thema/Themen/Photovoltaik.php
@@ -15,6 +15,9 @@ class Photovoltaik extends Bedarfsthema
 
     public function __construct()
     {
-        parent::__construct(self::ID, 'Photovoltaikversicherung', [PrivateSachversicherung::BETREIBERHAFTPFLICHT]);
+        parent::__construct(self::ID, 'Photovoltaikversicherung', [
+            PrivateSachversicherung::BETREIBERHAFTPFLICHT,
+            PrivateSachversicherung::PHOTOVOLTAIKVERSICHERUNG,
+        ]);
     }
 }

--- a/src/Werte/Bedarf/Thema/Themen/Risikoleben.php
+++ b/src/Werte/Bedarf/Thema/Themen/Risikoleben.php
@@ -3,7 +3,7 @@
 namespace Demv\Werte\Bedarf\Thema\Themen;
 
 use Demv\Werte\Bedarf\Thema\Bedarfsthema;
-use Demv\Werte\Sparte\Sparten\Vorsorge;
+use Demv\Werte\Sparte\Sparten\Risikolebensversicherung;
 
 /**
  * Class Risikoleben
@@ -21,7 +21,14 @@ class Risikoleben extends Bedarfsthema
         parent::__construct(
             self::ID,
             'Risikolebensversicherung',
-            [Vorsorge::RISIKOLEBEN],
+            [
+                Risikolebensversicherung::ID,
+                Risikolebensversicherung::TODESFALL_LEISTUNG_STEIGEND,
+                Risikolebensversicherung::TODESFALL_LEISTUNG_Fallend,
+                Risikolebensversicherung::VERBUNDENE_LEBEN,
+                Risikolebensversicherung::OHNE_GESUNDHEITSFRAGEN,
+                Risikolebensversicherung::TODESFALL_LEISTUNG_KONSTANT,
+            ],
             'Risikolebens&shy;versicherung'
         );
     }

--- a/src/Werte/Sparte/Sparten/RechtsschutzGewerbe.php
+++ b/src/Werte/Sparte/Sparten/RechtsschutzGewerbe.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Demv\Werte\Sparte\Sparten;
+
+/**
+ * Interface RechtsschutzGewerbe
+ * @package Demv\Werte\Sparte\Sparten
+ */
+interface RechtsschutzGewerbe
+{
+    const ID = 233;
+
+    const BERUF              = 414;
+    const VERKEHR            = 415;
+    const MIETER_EIGENTUEMER = 416;
+    const VERMIETER          = 417;
+    const FIRMEN             = 552;
+}

--- a/src/Werte/Sparte/Sparten/Risikolebensversicherung.php
+++ b/src/Werte/Sparte/Sparten/Risikolebensversicherung.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Demv\Werte\Sparte\Sparten;
+
+/**
+ * Interface Risikolebensversicherung
+ * @package Demv\Werte\Sparte\Sparten
+ */
+interface Risikolebensversicherung
+{
+    const ID = 136;
+
+    const TODESFALL_LEISTUNG_STEIGEND   = 563;
+    const TODESFALL_LEISTUNG_Fallend    = 564;
+    const VERBUNDENE_LEBEN              = 566;
+    const OHNE_GESUNDHEITSFRAGEN        = 567;
+    const TODESFALL_LEISTUNG_KONSTANT   = 569;
+}

--- a/src/Werte/Sparte/Sparten/Vorsorge.php
+++ b/src/Werte/Sparte/Sparten/Vorsorge.php
@@ -45,4 +45,5 @@ interface Vorsorge
     const FONDSGEBUNDEN_BAV = 221;
 
     const BETRIEBLICHE_KRANKENVERSICHERUNG = 235;
+    const MULTIRISK_INVALIDITAET = 537;
 }

--- a/src/Werte/Sparte/Sparten/Vorsorge.php
+++ b/src/Werte/Sparte/Sparten/Vorsorge.php
@@ -45,5 +45,5 @@ interface Vorsorge
     const FONDSGEBUNDEN_BAV = 221;
 
     const BETRIEBLICHE_KRANKENVERSICHERUNG = 235;
-    const MULTIRISK_INVALIDITAET = 537;
+    const MULTIRISK_INVALIDITAET           = 537;
 }


### PR DESCRIPTION
Einige Bedarfe in der neuen Beratung haben nicht den Switch um die "Sparteninfo" anzuwählen, da nicht alle entsprechenden Sparten einem Bedarfsthema zugeordnet sind. Dieser PR verknüpft weitere Sparten mit bestehenden Bedarfsthemen.