### PR TITLE
Add missing `extends ValueInterface` to BildungsabschlussInterface

### DIFF
--- a/src/Werte/Person/Bildungsabschluss/BildungsabschlussInterface.php
+++ b/src/Werte/Person/Bildungsabschluss/BildungsabschlussInterface.php
@@ -2,11 +2,13 @@
 
 namespace Demv\Werte\Person\Bildungsabschluss;
 
+use Demv\Werte\ValueInterface;
+
 /**
  * Interface BildungsabschlussInterface
  * @package Demv\Werte\Person\Bildungsabschluss
  */
-interface BildungsabschlussInterface
+interface BildungsabschlussInterface extends ValueInterface
 {
     /**
      * @return string


### PR DESCRIPTION
All other interfaces work this way, and all existing implementations of BildungsabschlussInterface also extend the Value class, i.e. they already implement the ValueInterface.