### PR TITLE
make AbstractProvider template parameter covariant

### DIFF
--- a/src/Werte/AbstractProvider.php
+++ b/src/Werte/AbstractProvider.php
@@ -5,7 +5,7 @@ namespace Demv\Werte;
 use Demv\Werte\Exception\EntryNotFoundException;
 
 /**
- * @template T of ValueInterface
+ * @template-covariant T of ValueInterface
  * @implements ProviderInterface<T>
  */
 abstract class AbstractProvider implements ProviderInterface


### PR DESCRIPTION
Phpstan in Professionalworks fails with

```
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   protected/modules/kundenakte/Export/AssetsArrayExport.php                                                                                                                                         
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  30     Parameter #1 $provider of static method Demv\Werte\Conversion\DataList::fromProvider() expects Demv\Werte\ProviderInterface<Demv\Werte\ValueInterface>, Demv\Werte\Fahrzeug\FahrzeugTypen given.  
         🪪  argument.type                                                                                                                                                                                 
         💡  Template type T on class Demv\Werte\ProviderInterface is not covariant. Learn more: https://phpstan.org/blog/whats-up-with-template-covariant                                                 
  40     Parameter #1 $provider of static method Demv\Werte\Conversion\DataList::fromProvider() expects Demv\Werte\ProviderInterface<Demv\Werte\ValueInterface>, Demv\Werte\Tierart\Tierarten given.       
         🪪  argument.type                                                                                                                                                                                 
         💡  Template type T on class Demv\Werte\ProviderInterface is not covariant. Learn more: https://phpstan.org/blog/whats-up-with-template-covariant                                                 
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   protected/modules/kundenakte/Export/HobbiesArrayExport.php                                                                                                                               
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  21     Parameter #1 $provider of static method Demv\Werte\Conversion\DataList::fromProvider() expects Demv\Werte\ProviderInterface<Demv\Werte\ValueInterface>, Demv\Werte\Hobby\Hobbies given.  
         🪪  argument.type                                                                                                                                                                        
         💡  Template type T on class Demv\Werte\ProviderInterface is not covariant. Learn more: https://phpstan.org/blog/whats-up-with-template-covariant                                        
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
```

Using covariant template allows the prevailing usage like this expression  

```
DataList::fromProvider(new FahrzeugTypen())
```