### PR TITLE
fix: explicit nullable type for Bedarfsthema $displayname

### DIFF
--- a/src/Werte/Bedarf/Thema/Bedarfsthema.php
+++ b/src/Werte/Bedarf/Thema/Bedarfsthema.php
@@ -28,7 +28,7 @@ class Bedarfsthema extends Value implements BedarfthemaInterface
      * @param array       $spartenids
      * @param string|null $displayname
      */
-    public function __construct(int $identifier, string $name, array $spartenids, string $displayname = null)
+    public function __construct(int $identifier, string $name, array $spartenids, ?string $displayname = null)
     {
         parent::__construct($identifier, $name);
         $this->spartenIds  = $spartenids;


### PR DESCRIPTION
PHP 8.4 deprecates implicitly marking a parameter nullable via a null default on a non-nullable type. 